### PR TITLE
Change the subscriptionId paremeter to be completely optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This action can be used to deploy Azure Resource Manager templates at different 
 
 * `scope`: Provide the scope of the deployment. Valid values are: `resourcegroup`(default) , `subscription`, `managementgroup`. 
 * `resourceGroupName`: **Conditional** Provide the name of a resource group. Only required for Resource Group Scope
-* `subscriptionId`: **Conditional** Provide the subscription ID  which should be used. Only required for scope `resourcegroup` & `subscription`. 
+* `subscriptionId`: **Conditional** Provide a value to override the subscription ID set by [Azure Login](https://github.com/Azure/login).
 * `managementGroupId`: **Conditional** Specify the Management Group ID, only required for Management Group Deployments.
 * `region`: **Conditional** Provide the target region, only required for Management Group or Subscription deployments.
 * `template`: **Required** Specify the path or URL to the Azure Resource Manager template.
@@ -52,7 +52,6 @@ jobs:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
     - uses: azure/arm-deploy@v1
       with:
-        subscriptionId: e1046c08-7072-****-****-************
         resourceGroupName: github-action-arm-rg
         template: ./azuredeploy.json
         parameters: storageAccountType=Standard_LRS
@@ -66,7 +65,6 @@ In this exmaple, our template outputs `containerName`.
 - uses: azure/arm-deploy@v1
   id: deploy
   with:
-    subscriptionId: e1046c08-7072-****-****-************
     resourceGroupName: azurearmaction
     template: examples/template/template.json
     parameters: examples/template/parameters.json

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: "Provide the scope of the deployment. Valid values are: 'resourcegroup', 'managementgroup', 'subscription'"
     required: true
   subscriptionId:
-    description: "Provide the Id of the subscription which should be used, only required for resource Group or Subscription deployments."
+    description: "Override the Subscription Id set by Azure Login."
     required: false
   managementGroupId:
     description: "Specify the Id for the Management Group, only required for Management Group Deployments."

--- a/examples/Advanced.md
+++ b/examples/Advanced.md
@@ -4,11 +4,10 @@ Our template has two outputs `location` and `containerName`. But we are only int
 
 ## Steps
 ```yaml
-- uses: whiteducksoftware/azure-arm-action-js@v3
+- uses: azure/arm-deploy@v1
   id: deploy
   with:
     scope: resourcegroup
-    subscriptionId: e1046c08-7072-****-****-************
     resourceGroupName: azurearmaction
     template: examples/template/template.json
     parameters: examples/template/parameters.json
@@ -37,11 +36,10 @@ we can see that on the console will be `github-action` printed.
 
 Now we add our second deployment which relies on that value and modfies the `containerName` parameter,
 ```yaml
-- uses: whiteducksoftware/azure-arm-action-js@v3
+- uses: azure/arm-deploy@v1
   id: deploy2
   with:
     scope: resourcegroup
-    subscriptionId: e1046c08-7072-****-****-************
     resourceGroupName: azurearmaction
     template: examples/template/template.json
     parameters: examples/template/parameters.json containerName=${{ steps.deploy.outputs.containerName }}-overriden

--- a/examples/advanced-example.yaml
+++ b/examples/advanced-example.yaml
@@ -15,11 +15,10 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - uses: whiteducksoftware/azure-arm-action-js@v3
+      - uses: azure/arm-deploy@v1
         id: deploy
         with:
           scope: resourcegroup
-          subscriptionId: e1046c08-7072-****-****-************
           resourceGroupName: azurearmaction
           template: examples/template/template.json
           parameters: examples/template/parameters.json
@@ -27,11 +26,10 @@ jobs:
 
       - run: echo ${{ steps.deploy.outputs.containerName }}
 
-      - uses: whiteducksoftware/azure-arm-action-js@v3
+      - uses: azure/arm-deploy@v1
         id: deploy2
         with:
           scope: resourcegroup
-          subscriptionId: e1046c08-7072-****-****-************
           resourceGroupName: azurearmaction
           template: examples/template/template.json
           parameters: examples/template/parameters.json containerName=${{ steps.deploy.outputs.containerName }}-overriden

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ export async function main(): Promise<Outputs> {
     const managementGroupId = getInput('managementGroupId')
 
     // change the subscription context
-    if (scope != "managementgroup") {
+    if (subscriptionId !== "") {
         info("Changing subscription context...")
         await exec(`"${azPath}" account set --subscription ${subscriptionId}`, [], { silent: true })
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ export async function main(): Promise<Outputs> {
     const managementGroupId = getInput('managementGroupId')
 
     // change the subscription context
-    if (subscriptionId !== "") {
+    if (scope !== "managementgroup" && subscriptionId !== "") {
         info("Changing subscription context...")
         await exec(`"${azPath}" account set --subscription ${subscriptionId}`, [], { silent: true })
     }


### PR DESCRIPTION
The Azure Login action already sets your subscription id:
https://github.com/Azure/login/blob/master/src/main.ts#L39

This change makes usage a bit cleaner.