### PR TITLE
modifying streams for exec

### DIFF
--- a/src/deploy/scope_managementgroup.ts
+++ b/src/deploy/scope_managementgroup.ts
@@ -34,11 +34,13 @@ export async function DeployManagementGroupScope(azPath: string, region: string,
             stderr: (data: BufferSource) => {
                 core.error(data.toString());
             },
-            stdline: (data: string) => {
-                if (!data.startsWith("[command]"))
-                    commandOutput += data;
-                // console.log(data);
+            stdout: (data: BufferSource) => {
+                commandOutput += data.toString();
+                // console.log(data.toString());
             },
+            debug: (data: string) => {
+                core.debug(data);
+            }
         }
     }
     const validateOptions: ExecOptions = {

--- a/src/deploy/scope_resourcegroup.ts
+++ b/src/deploy/scope_resourcegroup.ts
@@ -36,11 +36,13 @@ export async function DeployResourceGroupScope(azPath: string, resourceGroupName
             stderr: (data: BufferSource) => {
                 core.error(data.toString());
             },
-            stdline: (data: string) => {
-                if (!data.startsWith("[command]"))
-                    commandOutput += data;
-                // console.log(data);
+            stdout: (data: BufferSource) => {
+                commandOutput += data.toString();
+                // console.log(data.toString());
             },
+            debug: (data: string) => {
+                core.debug(data);
+            }
         }
     }
     const validateOptions: ExecOptions = {

--- a/src/deploy/scope_subscription.ts
+++ b/src/deploy/scope_subscription.ts
@@ -34,11 +34,13 @@ export async function DeploySubscriptionScope(azPath: string, region: string, te
             stderr: (data: BufferSource) => {
                 core.error(data.toString());
             },
-            stdline: (data: string) => {
-                if (!data.startsWith("[command]"))
-                    commandOutput += data;
-                // console.log(data);
+            stdout: (data: BufferSource) => {
+                commandOutput += data.toString();
+                // console.log(data.toString());
             },
+            debug: (data: string) => {
+                core.debug(data);
+            }
         }
     }
     const validateOptions: ExecOptions = {


### PR DESCRIPTION
Currently, the action uses `stderr` and `stdline` streams for handling the `az cli` commands' io streams. It appears that `stdline` fails once in a while for a line, which renders the expected JSON output of the `az cli` deployment commnand inconcistent. The current assumption for using the `stdline` was that the output could contains `[command]` lines as well, which the `task-lib` would be logging. However, on checking the toolkit code, we can see that those lines would get output to the `stdout` stream of the child process(if no listeners are provided, which is the case), whereas the actual output would be sent to the listeners. So, we can use `stdout` instead of `stdline`. We need to keep on appending `stdout` as well, since it has a limit for amount of data it can send at one time, so data is sent in buffers.
 
Fix for https://github.com/Azure/arm-deploy/issues/33