### PR TITLE
Removed additionalArguments while validation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ By default, the action only parses the output and does not print them out. In or
 * `deploymentMode`: `Incremental`(default) (only add resources to resource group) or `Complete` (remove extra resources from resource group) or `Validate` (only validates the template). 
 * `deploymentName`: Specifies the name of the resource group deployment to create.
 * `failOnStdErr`: Specify whether to fail the action if some data is written to stderr stream of az cli. Valid values are: true, false. Default value set to true.
-* `additionalArguments`: Specify any additional arguments for the deployment.
+* `additionalArguments`: Specify any additional arguments for the deployment. These arguments will be ignored while `validating` the template.
 
 ## Outputs
 Every template output will either be exported as output if output is a json object else will be consoled out where output is not a json object. 

--- a/src/deploy/scope_managementgroup.ts
+++ b/src/deploy/scope_managementgroup.ts
@@ -14,16 +14,20 @@ export async function DeployManagementGroupScope(azPath: string, region: string,
         core.warning("This deployment mode is not supported for management group scoped deployments, this parameter will be ignored!")
     }
     // create the parameter list
-    const azDeployParameters = [
+    const validateParameters = [
         region ? `--location "${region}"` : undefined,
         template ?
             template.startsWith("http") ? `--template-uri ${template}` : `--template-file ${template}`
             : undefined,
         managementGroupId ? `--management-group-id "${managementGroupId}"` : undefined,
         deploymentName ? `--name "${deploymentName}"` : undefined,
-        parameters ? `--parameters ${parameters}` : undefined,
-        additionalArguments ? additionalArguments : undefined
+        parameters ? `--parameters ${parameters}` : undefined
     ].filter(Boolean).join(' ');
+
+    let azDeployParameters = validateParameters;
+    if(additionalArguments){
+        azDeployParameters += additionalArguments;
+    }
 
     // configure exec to write the json output to a buffer
     let commandOutput = '';
@@ -61,7 +65,7 @@ export async function DeployManagementGroupScope(azPath: string, region: string,
 
     // validate the deployment
     core.info("Validating template...")
-    var code = await exec(`"${azPath}" deployment mg validate ${azDeployParameters} -o json`, [], validateOptions);
+    var code = await exec(`"${azPath}" deployment mg validate ${validateParameters} -o json`, [], validateOptions);
     if (deploymentMode === "validate" && code != 0) {
         throw new Error("Template validation failed.")
     } else if (code != 0) {

--- a/src/deploy/scope_resourcegroup.ts
+++ b/src/deploy/scope_resourcegroup.ts
@@ -16,16 +16,20 @@ export async function DeployResourceGroupScope(azPath: string, resourceGroupName
     }
 
     // create the parameter list
-    const azDeployParameters = [
+    const validateParameters = [
         resourceGroupName ? `--resource-group ${resourceGroupName}` : undefined,
         template ?
             template.startsWith("http") ? `--template-uri ${template}` : `--template-file ${template}`
             : undefined,
         deploymentMode && deploymentMode != "validate" ? `--mode ${deploymentMode}` : "--mode Incremental",
         deploymentName ? `--name "${deploymentName}"` : undefined,
-        parameters ? `--parameters ${parameters}` : undefined,
-        additionalArguments ? additionalArguments : undefined
+        parameters ? `--parameters ${parameters}` : undefined
     ].filter(Boolean).join(' ');
+
+    let azDeployParameters = validateParameters;
+    if(additionalArguments){
+        azDeployParameters += additionalArguments;
+    }
 
     // configure exec to write the json output to a buffer
     let commandOutput = '';
@@ -63,7 +67,7 @@ export async function DeployResourceGroupScope(azPath: string, resourceGroupName
 
     // validate the deployment
     core.info("Validating template...")
-    var code = await exec(`"${azPath}" deployment group validate ${azDeployParameters} -o json`, [], validateOptions);
+    var code = await exec(`"${azPath}" deployment group validate ${validateParameters} -o json`, [], validateOptions);
     if (deploymentMode === "validate" && code != 0) {
         throw new Error("Template validation failed.")
     } else if (code != 0) {

--- a/src/deploy/scope_subscription.ts
+++ b/src/deploy/scope_subscription.ts
@@ -15,15 +15,19 @@ export async function DeploySubscriptionScope(azPath: string, region: string, te
     }
 
     // create the parameter list
-    const azDeployParameters = [
+    const validateParameters = [
         region ? `--location "${region}"` : undefined,
         template ?
             template.startsWith("http") ? `--template-uri ${template}` : `--template-file ${template}`
             : undefined,
         deploymentName ? `--name "${deploymentName}"` : undefined,
-        parameters ? `--parameters ${parameters}` : undefined,
-        additionalArguments ? additionalArguments : undefined
+        parameters ? `--parameters ${parameters}` : undefined
     ].filter(Boolean).join(' ');
+
+    let azDeployParameters = validateParameters;
+    if(additionalArguments){
+        azDeployParameters += additionalArguments;
+    }
 
     // configure exec to write the json output to a buffer
     let commandOutput = '';
@@ -61,7 +65,7 @@ export async function DeploySubscriptionScope(azPath: string, region: string, te
 
     // validate the deployment
     core.info("Validating template...")
-    var code = await exec(`"${azPath}" deployment sub validate ${azDeployParameters} -o json`, [], validateOptions);
+    var code = await exec(`"${azPath}" deployment sub validate ${validateParameters} -o json`, [], validateOptions);
     if (deploymentMode === "validate" && code != 0) {
         throw new Error("Template validation failed.")
     } else if (code != 0) {


### PR DESCRIPTION
There are multiple parameters in additionalArguments which are not available for `validate` step. This leads to unnecessary warnings in the logs.  

This PR will create separate `validataeParameters` and `azDeployParameters` for their respective steps ensuring the success of validate step.

![alt-text](https://user-images.githubusercontent.com/34542414/143212185-52d6e4c6-6e54-49ad-b802-00ee5e530c57.png)