### PR TITLE
allow regist output value to github action as secret

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -126,7 +126,7 @@ jobs:
           resourceGroupName: arm-deploy-e2e
           parameters: test/bicep/inputs-outputs.bicepparam
           deploymentName: e2e-test-${{ matrix.os }}
-          maskedOutput: |
+          maskedOutputs: |
             mySecret
 
       - name: Print Result

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Print Result
         run: |
-          echo "StringOutput=${{ steps.deploy.stringOutput }}"
-          echo "intOutput=${{ steps.deploy.intOutput }}"
-          echo "objectOutput=${{ steps.deploy.objectOutput }}"
-          echo "mySecret=${{ steps.deploy.mySecret }}"
+          echo "StringOutput=${{ steps.deploy.outputs.stringOutput }}"
+          echo "intOutput=${{ steps.deploy.outputs.intOutput }}"
+          echo "objectOutput=${{ steps.deploy.outputs.objectOutput }}"
+          echo "mySecret=${{ steps.deploy.outputs.mySecret }}"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -136,4 +136,4 @@ jobs:
           echo "objectOutput=${{ steps.deploy.outputs.objectOutput }}"
           echo "myServerIP=${{ steps.deploy.outputs.myServerIP }}"
           # myServerIP is register as secret, it can still be accessed, just won't print in raw form.
-          echo "myServerIPEncoded=$(echo ${{ steps.deploy.outputs.myServerIP }} | base64)""
+          echo "myServerIPEncoded=$(echo ${{ steps.deploy.outputs.myServerIP }} | base64)"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -118,6 +118,7 @@ jobs:
           subscription-id: ${{ secrets.SUBSCRIPTION_ID }}
 
       - name: Run Action
+        id: deploy
         uses: ./
         with:
           scope: resourcegroup
@@ -127,3 +128,10 @@ jobs:
           deploymentName: e2e-test-${{ matrix.os }}
           maskedOutput: |
             mySecret
+
+      - name: Print Result
+        run: |
+          echo "StringOutput=${{ steps.deploy.stringOutput }}"
+          echo "intOutput=${{ steps.deploy.intOutput }}"
+          echo "objectOutput=${{ steps.deploy.objectOutput }}"
+          echo "mySecret=${{ steps.deploy.mySecret }}"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -125,5 +125,5 @@ jobs:
           resourceGroupName: arm-deploy-e2e
           parameters: test/bicep/inputs-outputs.bicepparam
           deploymentName: e2e-test-${{ matrix.os }}
-          maskedOutput:
-          - mySecret
+          maskedOutput: |
+            mySecret

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -127,11 +127,13 @@ jobs:
           parameters: test/bicep/inputs-outputs.bicepparam
           deploymentName: e2e-test-${{ matrix.os }}
           maskedOutputs: |
-            mySecret
+            myServerIP
 
       - name: Print Result
         run: |
           echo "StringOutput=${{ steps.deploy.outputs.stringOutput }}"
           echo "intOutput=${{ steps.deploy.outputs.intOutput }}"
           echo "objectOutput=${{ steps.deploy.outputs.objectOutput }}"
-          echo "mySecret=${{ steps.deploy.outputs.mySecret }}"
+          echo "myServerIP=${{ steps.deploy.outputs.myServerIP }}"
+          # myServerIP is register as secret, it can still be accessed, just won't print in raw form.
+          echo "myServerIPEncoded=$(echo ${{ steps.deploy.outputs.myServerIP }} | base64)""

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -125,3 +125,5 @@ jobs:
           resourceGroupName: arm-deploy-e2e
           parameters: test/bicep/inputs-outputs.bicepparam
           deploymentName: e2e-test-${{ matrix.os }}
+          maskedOutput:
+          - mySecret

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ By default, the action only parses the output and does not print them out. In or
 * `deploymentName`: Specifies the name of the resource group deployment to create.
 * `failOnStdErr`: Specify whether to fail the action if some data is written to stderr stream of az cli. Valid values are: true, false. Default value set to true.
 * `additionalArguments`: Specify any additional arguments for the deployment. These arguments will be ignored while `validating` the template.
+* `maskedOutputs`: Specify list of output keys that its value need to be register to github action as secret. (checkout https://github.com/actions/toolkit/issues/184#issuecomment-1198653452 for valid multiline string)
 
   A good way to use additionalArguments would be to send optional parameters like `--what-if` or `--what-if-exclude-change-types`. [Read more about this here](https://docs.microsoft.com/en-us/cli/azure/deployment?view=azure-cli-latest#az-deployment-create-optional-parameters)
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
   additionalArguments:
     description: "Specify any additional arguments for the deployment."
     required: false
-  maskedOutput:
+  maskedOutputs:
     description: "Specify any out put need to set as secret, so github action log won't print them out."
     required: false
 branding:

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,9 @@ inputs:
   additionalArguments:
     description: "Specify any additional arguments for the deployment."
     required: false
+  maskedOutput:
+    description: "Specify any out put need to set as secret, so github action log won't print them out."
+    required: false
 branding:
   color: orange
   icon: package

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
     description: "Specify any additional arguments for the deployment."
     required: false
   maskedOutputs:
-    description: "Specify any output need to set as secret, so github action log won't print them out."
+    description: "Specify list of output keys that its value need to be register to github action as secret. (checkout https://github.com/actions/toolkit/issues/184#issuecomment-1198653452 for valid multiline string)"
     required: false
 branding:
   color: orange

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
     description: "Specify any additional arguments for the deployment."
     required: false
   maskedOutputs:
-    description: "Specify any out put need to set as secret, so github action log won't print them out."
+    description: "Specify any output need to set as secret, so github action log won't print them out."
     required: false
 branding:
   color: orange

--- a/dist/index.js
+++ b/dist/index.js
@@ -4309,6 +4309,7 @@ function deploy(options) {
             (0, core_1.info)("Changing subscription context...");
             yield azCli.setSubscriptionContext(subscriptionId);
         }
+        (0, core_1.info)("options: " + JSON.stringify(options));
         // Run the Deployment
         switch (scope) {
             case "resourcegroup":

--- a/dist/index.js
+++ b/dist/index.js
@@ -3919,7 +3919,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 1337:
+/***/ 669:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -3961,8 +3961,8 @@ exports.deployManagementGroupScope = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const core = __importStar(__nccwpck_require__(2186));
-const utils_1 = __nccwpck_require__(5712);
-function deployManagementGroupScope(azCli, region, template, deploymentMode, deploymentName, parameters, managementGroupId, failOnStdErr, additionalArguments) {
+const utils_1 = __nccwpck_require__(239);
+function deployManagementGroupScope(azCli, region, template, deploymentMode, deploymentName, parameters, managementGroupId, failOnStdErr, maskedOutputs, additionalArguments) {
     return __awaiter(this, void 0, void 0, function* () {
         // Check if region is set
         if (!region) {
@@ -3990,16 +3990,16 @@ function deployManagementGroupScope(azCli, region, template, deploymentMode, dep
         if (deploymentMode != "validate") {
             // execute the deployment
             core.info("Creating deployment...");
-            return yield azCli.deploy(`deployment mg create ${azDeployParameters} -o json`, failOnStdErr);
+            return yield azCli.deploy(`deployment mg create ${azDeployParameters} -o json`, maskedOutputs, failOnStdErr);
         }
     });
 }
 exports.deployManagementGroupScope = deployManagementGroupScope;
-//# sourceMappingURL=scope_managementgroup.js.map
+
 
 /***/ }),
 
-/***/ 7539:
+/***/ 6887:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4041,8 +4041,8 @@ exports.deployResourceGroupScope = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const core = __importStar(__nccwpck_require__(2186));
-const utils_1 = __nccwpck_require__(5712);
-function deployResourceGroupScope(azCli, resourceGroupName, template, deploymentMode, deploymentName, parameters, failOnStdErr, additionalArguments) {
+const utils_1 = __nccwpck_require__(239);
+function deployResourceGroupScope(azCli, resourceGroupName, template, deploymentMode, deploymentName, parameters, failOnStdErr, maskedOutputs, additionalArguments) {
     return __awaiter(this, void 0, void 0, function* () {
         // Check if resourceGroupName is set
         if (!resourceGroupName) {
@@ -4071,16 +4071,16 @@ function deployResourceGroupScope(azCli, resourceGroupName, template, deployment
         if (deploymentMode != "validate") {
             // execute the deployment
             core.info("Creating deployment...");
-            return yield azCli.deploy(`deployment group create ${azDeployParameters} -o json`, failOnStdErr);
+            return yield azCli.deploy(`deployment group create ${azDeployParameters} -o json`, maskedOutputs, failOnStdErr);
         }
     });
 }
 exports.deployResourceGroupScope = deployResourceGroupScope;
-//# sourceMappingURL=scope_resourcegroup.js.map
+
 
 /***/ }),
 
-/***/ 2979:
+/***/ 8201:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4122,8 +4122,8 @@ exports.deploySubscriptionScope = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const core = __importStar(__nccwpck_require__(2186));
-const utils_1 = __nccwpck_require__(5712);
-function deploySubscriptionScope(azCli, region, template, deploymentMode, deploymentName, parameters, failOnStdErr, additionalArguments) {
+const utils_1 = __nccwpck_require__(239);
+function deploySubscriptionScope(azCli, region, template, deploymentMode, deploymentName, parameters, failOnStdErr, maskedOutputs, additionalArguments) {
     return __awaiter(this, void 0, void 0, function* () {
         // Check if region is set
         if (!region) {
@@ -4149,16 +4149,16 @@ function deploySubscriptionScope(azCli, region, template, deploymentMode, deploy
         if (deploymentMode != "validate") {
             // execute the deployment
             core.info("Creating deployment...");
-            return yield azCli.deploy(`deployment sub create ${azDeployParameters} -o json`, failOnStdErr);
+            return yield azCli.deploy(`deployment sub create ${azDeployParameters} -o json`, maskedOutputs, failOnStdErr);
         }
     });
 }
 exports.deploySubscriptionScope = deploySubscriptionScope;
-//# sourceMappingURL=scope_subscription.js.map
+
 
 /***/ }),
 
-/***/ 5296:
+/***/ 1368:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4200,8 +4200,8 @@ exports.deployTenantScope = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const core = __importStar(__nccwpck_require__(2186));
-const utils_1 = __nccwpck_require__(5712);
-function deployTenantScope(azCli, region, template, deploymentMode, deploymentName, parameters, failOnStdErr, additionalArguments) {
+const utils_1 = __nccwpck_require__(239);
+function deployTenantScope(azCli, region, template, deploymentMode, deploymentName, parameters, failOnStdErr, maskedOutputs, additionalArguments) {
     return __awaiter(this, void 0, void 0, function* () {
         // Check if region is set
         if (!region) {
@@ -4227,16 +4227,16 @@ function deployTenantScope(azCli, region, template, deploymentMode, deploymentNa
         if (deploymentMode != "validate") {
             // execute the deployment
             core.info("Creating deployment...");
-            return yield azCli.deploy(`deployment tenant create ${azDeployParameters} -o json`, failOnStdErr);
+            return yield azCli.deploy(`deployment tenant create ${azDeployParameters} -o json`, maskedOutputs, failOnStdErr);
         }
     });
 }
 exports.deployTenantScope = deployTenantScope;
-//# sourceMappingURL=scope_tenant.js.map
+
 
 /***/ }),
 
-/***/ 1713:
+/***/ 399:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4255,11 +4255,11 @@ exports.main = exports.deploy = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const core_1 = __nccwpck_require__(2186);
-const scope_resourcegroup_1 = __nccwpck_require__(7539);
-const scope_tenant_1 = __nccwpck_require__(5296);
-const scope_managementgroup_1 = __nccwpck_require__(1337);
-const scope_subscription_1 = __nccwpck_require__(2979);
-const azhelper_1 = __nccwpck_require__(3673);
+const scope_resourcegroup_1 = __nccwpck_require__(6887);
+const scope_tenant_1 = __nccwpck_require__(1368);
+const scope_managementgroup_1 = __nccwpck_require__(669);
+const scope_subscription_1 = __nccwpck_require__(8201);
+const azhelper_1 = __nccwpck_require__(7664);
 function populateOptions() {
     return __awaiter(this, void 0, void 0, function* () {
         const scope = (0, core_1.getInput)("scope") || "resourcegroup";
@@ -4272,6 +4272,7 @@ function populateOptions() {
         const parameters = (0, core_1.getInput)("parameters");
         const managementGroupId = (0, core_1.getInput)("managementGroupId");
         const additionalArguments = (0, core_1.getInput)("additionalArguments");
+        const maskedOutputs = (0, core_1.getMultilineInput)("maskedOutputs");
         let failOnStdErr;
         try {
             failOnStdErr = (0, core_1.getBooleanInput)("failOnStdErr");
@@ -4290,6 +4291,7 @@ function populateOptions() {
             parameters,
             managementGroupId,
             additionalArguments,
+            maskedOutputs,
             failOnStdErr,
         };
     });
@@ -4299,7 +4301,7 @@ function deploy(options) {
         // determine az path
         const azCli = yield (0, azhelper_1.getAzCliHelper)();
         // retrieve action variables
-        const { scope, subscriptionId, region: region, resourceGroupName, template, deploymentMode, deploymentName, parameters, managementGroupId, additionalArguments, failOnStdErr, } = options;
+        const { scope, subscriptionId, region: region, resourceGroupName, template, deploymentMode, deploymentName, parameters, managementGroupId, additionalArguments, maskedOutputs, failOnStdErr, } = options;
         // change the subscription context
         if (scope !== "tenant" &&
             scope !== "managementgroup" &&
@@ -4310,13 +4312,13 @@ function deploy(options) {
         // Run the Deployment
         switch (scope) {
             case "resourcegroup":
-                return yield (0, scope_resourcegroup_1.deployResourceGroupScope)(azCli, resourceGroupName, template, deploymentMode, deploymentName, parameters, failOnStdErr, additionalArguments);
+                return yield (0, scope_resourcegroup_1.deployResourceGroupScope)(azCli, resourceGroupName, template, deploymentMode, deploymentName, parameters, failOnStdErr, maskedOutputs, additionalArguments);
             case "tenant":
-                return yield (0, scope_tenant_1.deployTenantScope)(azCli, region, template, deploymentMode, deploymentName, parameters, failOnStdErr, additionalArguments);
+                return yield (0, scope_tenant_1.deployTenantScope)(azCli, region, template, deploymentMode, deploymentName, parameters, failOnStdErr, maskedOutputs, additionalArguments);
             case "managementgroup":
-                return yield (0, scope_managementgroup_1.deployManagementGroupScope)(azCli, region, template, deploymentMode, deploymentName, parameters, managementGroupId, failOnStdErr, additionalArguments);
+                return yield (0, scope_managementgroup_1.deployManagementGroupScope)(azCli, region, template, deploymentMode, deploymentName, parameters, managementGroupId, failOnStdErr, maskedOutputs, additionalArguments);
             case "subscription":
-                return yield (0, scope_subscription_1.deploySubscriptionScope)(azCli, region, template, deploymentMode, deploymentName, parameters, failOnStdErr, additionalArguments);
+                return yield (0, scope_subscription_1.deploySubscriptionScope)(azCli, region, template, deploymentMode, deploymentName, parameters, failOnStdErr, maskedOutputs, additionalArguments);
             default:
                 throw new Error("Invalid scope. Valid values are: 'resourcegroup', 'tenant', 'managementgroup', 'subscription'");
         }
@@ -4341,11 +4343,11 @@ function main() {
     });
 }
 exports.main = main;
-//# sourceMappingURL=main.js.map
+
 
 /***/ }),
 
-/***/ 3673:
+/***/ 7664:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4388,7 +4390,7 @@ exports.getAzCliHelper = exports.AzCliHelper = void 0;
 // Licensed under the MIT License.
 const exec_1 = __nccwpck_require__(1514);
 const core = __importStar(__nccwpck_require__(2186));
-const utils_1 = __nccwpck_require__(5712);
+const utils_1 = __nccwpck_require__(239);
 const io_1 = __nccwpck_require__(7436);
 class AzCliHelper {
     constructor(azPath) {
@@ -4420,7 +4422,7 @@ function resourceGroupExists(azPath, resourceGroupName) {
         return exitCode === 0;
     });
 }
-function deploy(azPath, command, failOnStdErr) {
+function deploy(azPath, command, maskedOutputs, failOnStdErr) {
     return __awaiter(this, void 0, void 0, function* () {
         let hasStdErr = false;
         let stdOut = "";
@@ -4453,7 +4455,9 @@ function deploy(azPath, command, failOnStdErr) {
         }
         core.debug(stdOut);
         core.info("Parsing outputs...");
-        return (0, utils_1.getDeploymentResult)(stdOut);
+        const result = (0, utils_1.getDeploymentResult)(stdOut, maskedOutputs);
+        core.debug(stdOut);
+        return result;
     });
 }
 function validate(azPath, command, failOnNonZeroExit) {
@@ -4481,12 +4485,12 @@ function callAzCli(azPath, command, options) {
         return yield (0, exec_1.exec)(`"${azPath}" ${command}`, [], options);
     });
 }
-//# sourceMappingURL=azhelper.js.map
+
 
 /***/ }),
 
-/***/ 5712:
-/***/ ((__unused_webpack_module, exports) => {
+/***/ 239:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
@@ -4494,13 +4498,18 @@ function callAzCli(azPath, command, options) {
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.joinCliArguments = exports.getDeploymentResult = void 0;
-function getDeploymentResult(commandOutput) {
+const core_1 = __nccwpck_require__(2186);
+function getDeploymentResult(commandOutput, maskedOutputs) {
     // parse the result and save the outputs
     const outputs = {};
     try {
         const parsed = JSON.parse(commandOutput);
         for (const key in parsed.properties.outputs) {
-            outputs[key] = parsed.properties.outputs[key].value;
+            const maskedValue = parsed.properties.outputs[key].value.toString();
+            if (maskedOutputs && maskedOutputs.includes(key)) {
+                (0, core_1.setSecret)(maskedValue);
+            }
+            outputs[key] = maskedValue;
         }
     }
     catch (err) {
@@ -4515,7 +4524,7 @@ function joinCliArguments(...args) {
     return args.filter(Boolean).join(" ");
 }
 exports.joinCliArguments = joinCliArguments;
-//# sourceMappingURL=utils.js.map
+
 
 /***/ }),
 
@@ -4678,7 +4687,7 @@ var exports = __webpack_exports__;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-const main_1 = __nccwpck_require__(1713);
+const main_1 = __nccwpck_require__(399);
 (0, main_1.main)();
 
 })();

--- a/dist/index.js
+++ b/dist/index.js
@@ -4506,7 +4506,7 @@ function getDeploymentResult(commandOutput, maskedOutputs) {
         const parsed = JSON.parse(commandOutput);
         for (const key in parsed.properties.outputs) {
             const maskedValue = parsed.properties.outputs[key].value;
-            if (maskedOutputs && maskedOutputs.includes(key)) {
+            if (maskedOutputs && maskedOutputs.some(maskedKey => maskedKey === key)) {
                 (0, core_1.warning)("secret key matched for " + key);
                 (0, core_1.setSecret)(JSON.stringify(maskedValue));
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -3919,7 +3919,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 669:
+/***/ 1337:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -3961,7 +3961,7 @@ exports.deployManagementGroupScope = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const core = __importStar(__nccwpck_require__(2186));
-const utils_1 = __nccwpck_require__(239);
+const utils_1 = __nccwpck_require__(5712);
 function deployManagementGroupScope(azCli, region, template, deploymentMode, deploymentName, parameters, managementGroupId, failOnStdErr, additionalArguments) {
     return __awaiter(this, void 0, void 0, function* () {
         // Check if region is set
@@ -3995,11 +3995,11 @@ function deployManagementGroupScope(azCli, region, template, deploymentMode, dep
     });
 }
 exports.deployManagementGroupScope = deployManagementGroupScope;
-
+//# sourceMappingURL=scope_managementgroup.js.map
 
 /***/ }),
 
-/***/ 6887:
+/***/ 7539:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4041,7 +4041,7 @@ exports.deployResourceGroupScope = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const core = __importStar(__nccwpck_require__(2186));
-const utils_1 = __nccwpck_require__(239);
+const utils_1 = __nccwpck_require__(5712);
 function deployResourceGroupScope(azCli, resourceGroupName, template, deploymentMode, deploymentName, parameters, failOnStdErr, additionalArguments) {
     return __awaiter(this, void 0, void 0, function* () {
         // Check if resourceGroupName is set
@@ -4076,11 +4076,11 @@ function deployResourceGroupScope(azCli, resourceGroupName, template, deployment
     });
 }
 exports.deployResourceGroupScope = deployResourceGroupScope;
-
+//# sourceMappingURL=scope_resourcegroup.js.map
 
 /***/ }),
 
-/***/ 8201:
+/***/ 2979:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4122,7 +4122,7 @@ exports.deploySubscriptionScope = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const core = __importStar(__nccwpck_require__(2186));
-const utils_1 = __nccwpck_require__(239);
+const utils_1 = __nccwpck_require__(5712);
 function deploySubscriptionScope(azCli, region, template, deploymentMode, deploymentName, parameters, failOnStdErr, additionalArguments) {
     return __awaiter(this, void 0, void 0, function* () {
         // Check if region is set
@@ -4154,11 +4154,11 @@ function deploySubscriptionScope(azCli, region, template, deploymentMode, deploy
     });
 }
 exports.deploySubscriptionScope = deploySubscriptionScope;
-
+//# sourceMappingURL=scope_subscription.js.map
 
 /***/ }),
 
-/***/ 1368:
+/***/ 5296:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4200,7 +4200,7 @@ exports.deployTenantScope = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const core = __importStar(__nccwpck_require__(2186));
-const utils_1 = __nccwpck_require__(239);
+const utils_1 = __nccwpck_require__(5712);
 function deployTenantScope(azCli, region, template, deploymentMode, deploymentName, parameters, failOnStdErr, additionalArguments) {
     return __awaiter(this, void 0, void 0, function* () {
         // Check if region is set
@@ -4232,11 +4232,11 @@ function deployTenantScope(azCli, region, template, deploymentMode, deploymentNa
     });
 }
 exports.deployTenantScope = deployTenantScope;
-
+//# sourceMappingURL=scope_tenant.js.map
 
 /***/ }),
 
-/***/ 399:
+/***/ 1713:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4255,11 +4255,11 @@ exports.main = exports.deploy = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const core_1 = __nccwpck_require__(2186);
-const scope_resourcegroup_1 = __nccwpck_require__(6887);
-const scope_tenant_1 = __nccwpck_require__(1368);
-const scope_managementgroup_1 = __nccwpck_require__(669);
-const scope_subscription_1 = __nccwpck_require__(8201);
-const azhelper_1 = __nccwpck_require__(7664);
+const scope_resourcegroup_1 = __nccwpck_require__(7539);
+const scope_tenant_1 = __nccwpck_require__(5296);
+const scope_managementgroup_1 = __nccwpck_require__(1337);
+const scope_subscription_1 = __nccwpck_require__(2979);
+const azhelper_1 = __nccwpck_require__(3673);
 function populateOptions() {
     return __awaiter(this, void 0, void 0, function* () {
         const scope = (0, core_1.getInput)("scope") || "resourcegroup";
@@ -4341,11 +4341,11 @@ function main() {
     });
 }
 exports.main = main;
-
+//# sourceMappingURL=main.js.map
 
 /***/ }),
 
-/***/ 7664:
+/***/ 3673:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4388,7 +4388,7 @@ exports.getAzCliHelper = exports.AzCliHelper = void 0;
 // Licensed under the MIT License.
 const exec_1 = __nccwpck_require__(1514);
 const core = __importStar(__nccwpck_require__(2186));
-const utils_1 = __nccwpck_require__(239);
+const utils_1 = __nccwpck_require__(5712);
 const io_1 = __nccwpck_require__(7436);
 class AzCliHelper {
     constructor(azPath) {
@@ -4481,11 +4481,11 @@ function callAzCli(azPath, command, options) {
         return yield (0, exec_1.exec)(`"${azPath}" ${command}`, [], options);
     });
 }
-
+//# sourceMappingURL=azhelper.js.map
 
 /***/ }),
 
-/***/ 239:
+/***/ 5712:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -4515,7 +4515,7 @@ function joinCliArguments(...args) {
     return args.filter(Boolean).join(" ");
 }
 exports.joinCliArguments = joinCliArguments;
-
+//# sourceMappingURL=utils.js.map
 
 /***/ }),
 
@@ -4678,7 +4678,7 @@ var exports = __webpack_exports__;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-const main_1 = __nccwpck_require__(399);
+const main_1 = __nccwpck_require__(1713);
 (0, main_1.main)();
 
 })();

--- a/dist/index.js
+++ b/dist/index.js
@@ -4504,11 +4504,15 @@ function getDeploymentResult(commandOutput, maskedOutputs) {
     const outputs = {};
     try {
         const parsed = JSON.parse(commandOutput);
+        (0, core_1.warning)("try register secret for keys: " + maskedOutputs);
         for (const key in parsed.properties.outputs) {
             const maskedValue = parsed.properties.outputs[key].value;
             if (maskedOutputs && maskedOutputs.some(maskedKey => maskedKey === key)) {
                 (0, core_1.warning)("secret key matched for " + key);
                 (0, core_1.setSecret)(JSON.stringify(maskedValue));
+            }
+            else {
+                (0, core_1.warning)("no match for: " + key);
             }
             outputs[key] = maskedValue;
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -4505,9 +4505,10 @@ function getDeploymentResult(commandOutput, maskedOutputs) {
     try {
         const parsed = JSON.parse(commandOutput);
         for (const key in parsed.properties.outputs) {
-            const maskedValue = parsed.properties.outputs[key].value.toString();
+            const maskedValue = parsed.properties.outputs[key].value;
             if (maskedOutputs && maskedOutputs.includes(key)) {
-                (0, core_1.setSecret)(maskedValue);
+                (0, core_1.warning)("secret key matched for " + key);
+                (0, core_1.setSecret)(JSON.stringify(maskedValue));
             }
             outputs[key] = maskedValue;
         }

--- a/src/deploy/scope_managementgroup.ts
+++ b/src/deploy/scope_managementgroup.ts
@@ -13,6 +13,7 @@ export async function deployManagementGroupScope(
   parameters: string | undefined,
   managementGroupId: string,
   failOnStdErr: boolean,
+  maskedOutputs: string[] | undefined,
   additionalArguments: string | undefined,
 ): Promise<DeploymentResult | undefined> {
   // Check if region is set
@@ -59,6 +60,7 @@ export async function deployManagementGroupScope(
     core.info("Creating deployment...");
     return await azCli.deploy(
       `deployment mg create ${azDeployParameters} -o json`,
+      maskedOutputs,
       failOnStdErr,
     );
   }

--- a/src/deploy/scope_resourcegroup.ts
+++ b/src/deploy/scope_resourcegroup.ts
@@ -12,6 +12,7 @@ export async function deployResourceGroupScope(
   deploymentName: string,
   parameters: string | undefined,
   failOnStdErr: boolean,
+  maskedOutputs: string[] | undefined,
   additionalArguments: string | undefined,
 ): Promise<DeploymentResult | undefined> {
   // Check if resourceGroupName is set
@@ -57,6 +58,7 @@ export async function deployResourceGroupScope(
     core.info("Creating deployment...");
     return await azCli.deploy(
       `deployment group create ${azDeployParameters} -o json`,
+      maskedOutputs,
       failOnStdErr,
     );
   }

--- a/src/deploy/scope_subscription.ts
+++ b/src/deploy/scope_subscription.ts
@@ -12,6 +12,7 @@ export async function deploySubscriptionScope(
   deploymentName: string,
   parameters: string | undefined,
   failOnStdErr: boolean,
+  maskedOutputs: string[] | undefined,
   additionalArguments: string | undefined,
 ): Promise<DeploymentResult | undefined> {
   // Check if region is set
@@ -55,6 +56,7 @@ export async function deploySubscriptionScope(
     core.info("Creating deployment...");
     return await azCli.deploy(
       `deployment sub create ${azDeployParameters} -o json`,
+      maskedOutputs,
       failOnStdErr,
     );
   }

--- a/src/deploy/scope_tenant.ts
+++ b/src/deploy/scope_tenant.ts
@@ -12,6 +12,7 @@ export async function deployTenantScope(
   deploymentName: string,
   parameters: string | undefined,
   failOnStdErr: boolean,
+  maskedOutputs: string[] | undefined,
   additionalArguments: string | undefined,
 ): Promise<DeploymentResult | undefined> {
   // Check if region is set
@@ -54,6 +55,7 @@ export async function deployTenantScope(
     core.info("Creating deployment...");
     return await azCli.deploy(
       `deployment tenant create ${azDeployParameters} -o json`,
+      maskedOutputs,
       failOnStdErr,
     );
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,6 +97,8 @@ export async function deploy(
     await azCli.setSubscriptionContext(subscriptionId);
   }
 
+  info("options: " + JSON.stringify(options));
+
   // Run the Deployment
   switch (scope) {
     case "resourcegroup":

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import {
   getBooleanInput,
   info,
   getInput,
+  getMultilineInput,
   setFailed,
   setOutput,
 } from "@actions/core";
@@ -25,6 +26,7 @@ export type Options = {
   deploymentName: string;
   parameters?: string;
   additionalArguments?: string;
+  maskedOutputs?: string[];
   failOnStdErr: boolean;
 };
 
@@ -39,6 +41,7 @@ async function populateOptions(): Promise<Options> {
   const parameters = getInput("parameters");
   const managementGroupId = getInput("managementGroupId");
   const additionalArguments = getInput("additionalArguments");
+  const maskedOutputs = getMultilineInput("maskedOutputs");
   let failOnStdErr;
   try {
     failOnStdErr = getBooleanInput("failOnStdErr");
@@ -57,6 +60,7 @@ async function populateOptions(): Promise<Options> {
     parameters,
     managementGroupId,
     additionalArguments,
+    maskedOutputs,
     failOnStdErr,
   };
 }
@@ -79,6 +83,7 @@ export async function deploy(
     parameters,
     managementGroupId,
     additionalArguments,
+    maskedOutputs,
     failOnStdErr,
   } = options;
 
@@ -103,6 +108,7 @@ export async function deploy(
         deploymentName,
         parameters,
         failOnStdErr,
+        maskedOutputs,
         additionalArguments,
       );
 
@@ -115,6 +121,7 @@ export async function deploy(
         deploymentName,
         parameters,
         failOnStdErr,
+        maskedOutputs,
         additionalArguments,
       );
 
@@ -128,6 +135,7 @@ export async function deploy(
         parameters,
         managementGroupId,
         failOnStdErr,
+        maskedOutputs,
         additionalArguments,
       );
 
@@ -140,6 +148,7 @@ export async function deploy(
         deploymentName,
         parameters,
         failOnStdErr,
+        maskedOutputs,
         additionalArguments,
       );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,8 +97,6 @@ export async function deploy(
     await azCli.setSubscriptionContext(subscriptionId);
   }
 
-  info("options: " + JSON.stringify(options));
-
   // Run the Deployment
   switch (scope) {
     case "resourcegroup":

--- a/src/utils/azhelper.ts
+++ b/src/utils/azhelper.ts
@@ -72,9 +72,10 @@ async function deploy(azPath: string, command: string, maskedOutputs: string[]|u
     );
   }
 
-  core.debug(stdOut);
   core.info("Parsing outputs...");
+  // getDeploymentResult handles the secret masking
   const result = getDeploymentResult(stdOut, maskedOutputs);
+  // print stdOut only after secret masking
   core.debug(stdOut);
   return result
 }

--- a/src/utils/azhelper.ts
+++ b/src/utils/azhelper.ts
@@ -72,9 +72,11 @@ async function deploy(azPath: string, command: string, maskedOutputs: string[]|u
     );
   }
 
-  //core.debug(stdOut);
+  core.debug(stdOut);
   core.info("Parsing outputs...");
-  return getDeploymentResult(stdOut, maskedOutputs);
+  const result = getDeploymentResult(stdOut, maskedOutputs);
+  core.debug(stdOut);
+  return result
 }
 
 async function validate(

--- a/src/utils/azhelper.ts
+++ b/src/utils/azhelper.ts
@@ -36,7 +36,7 @@ async function resourceGroupExists(azPath: string, resourceGroupName: string) {
   return exitCode === 0;
 }
 
-async function deploy(azPath: string, command: string, failOnStdErr: boolean) {
+async function deploy(azPath: string, command: string, maskedOutputs: string[]|undefined, failOnStdErr: boolean) {
   let hasStdErr = false;
   let stdOut = "";
   const options: ExecOptions = {
@@ -72,9 +72,9 @@ async function deploy(azPath: string, command: string, failOnStdErr: boolean) {
     );
   }
 
-  core.debug(stdOut);
+  //core.debug(stdOut);
   core.info("Parsing outputs...");
-  return getDeploymentResult(stdOut);
+  return getDeploymentResult(stdOut, maskedOutputs);
 }
 
 async function validate(

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -21,11 +21,14 @@ export function getDeploymentResult(commandOutput: string, maskedOutputs: string
       };
     };
 
+    warning("try register secret for keys: " + maskedOutputs);
     for (const key in parsed.properties.outputs) {
       const maskedValue = parsed.properties.outputs[key].value;
       if (maskedOutputs && maskedOutputs.some(maskedKey => maskedKey === key)) {
         warning("secret key matched for " + key);
         setSecret(JSON.stringify(maskedValue));
+      } else {
+        warning("no match for: " + key);
       }
       outputs[key] = maskedValue;
     }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { warning, setSecret } from "@actions/core";
+import { debug, setSecret } from "@actions/core";
 
 export type DeploymentResult = {
   outputs: Record<string, unknown>;
@@ -21,14 +21,12 @@ export function getDeploymentResult(commandOutput: string, maskedOutputs: string
       };
     };
 
-    warning("try register secret for keys: " + maskedOutputs);
+    debug("registering secrets for keys: " + maskedOutputs);
     for (const key in parsed.properties.outputs) {
       const maskedValue = parsed.properties.outputs[key].value;
       if (maskedOutputs && maskedOutputs.some(maskedKey => maskedKey === key)) {
-        warning("secret key matched for " + key);
         setSecret(JSON.stringify(maskedValue));
-      } else {
-        warning("no match for: " + key);
+        debug("registered output value as secret for key: " + key);
       }
       outputs[key] = maskedValue;
     }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -15,17 +15,18 @@ export function getDeploymentResult(commandOutput: string, maskedOutputs: string
       properties: {
         outputs: {
           [index: string]: {
-            value: unknown;
+            value: any;
           };
         };
       };
     };
 
     for (const key in parsed.properties.outputs) {
+      const maskedValue = parsed.properties.outputs[key].value;
       if (maskedOutputs && maskedOutputs.includes(key)) {
-        setSecret(parsed.properties.outputs[key].value.toString());
+        setSecret(maskedValue.toString());
       }
-      outputs[key] = parsed.properties.outputs[key].value;
+      outputs[key] = maskedValue;
     }
   } catch (err) {
     console.error(commandOutput);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import {setSecret} from "@actions/core";
+import { warning, setSecret } from "@actions/core";
 
 export type DeploymentResult = {
   outputs: Record<string, unknown>;
@@ -22,9 +22,10 @@ export function getDeploymentResult(commandOutput: string, maskedOutputs: string
     };
 
     for (const key in parsed.properties.outputs) {
-      const maskedValue = parsed.properties.outputs[key].value.toString();
+      const maskedValue = parsed.properties.outputs[key].value;
       if (maskedOutputs && maskedOutputs.includes(key)) {
-        setSecret(maskedValue);
+        warning("secret key matched for " + key);
+        setSecret(JSON.stringify(maskedValue));
       }
       outputs[key] = maskedValue;
     }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -23,7 +23,7 @@ export function getDeploymentResult(commandOutput: string, maskedOutputs: string
 
     for (const key in parsed.properties.outputs) {
       const maskedValue = parsed.properties.outputs[key].value;
-      if (maskedOutputs && maskedOutputs.includes(key)) {
+      if (maskedOutputs && maskedOutputs.some(maskedKey => maskedKey === key)) {
         warning("secret key matched for " + key);
         setSecret(JSON.stringify(maskedValue));
       }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -22,9 +22,9 @@ export function getDeploymentResult(commandOutput: string, maskedOutputs: string
     };
 
     for (const key in parsed.properties.outputs) {
-      const maskedValue = parsed.properties.outputs[key].value;
+      const maskedValue = parsed.properties.outputs[key].value.toString();
       if (maskedOutputs && maskedOutputs.includes(key)) {
-        setSecret(maskedValue.toString());
+        setSecret(maskedValue);
       }
       outputs[key] = maskedValue;
     }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import {setSecret} from "@actions/core";
+
 export type DeploymentResult = {
   outputs: Record<string, unknown>;
 };
 
-export function getDeploymentResult(commandOutput: string): DeploymentResult {
+export function getDeploymentResult(commandOutput: string, maskedOutputs: string[]|undefined): DeploymentResult {
   // parse the result and save the outputs
   const outputs: Record<string, unknown> = {};
   try {
@@ -20,6 +22,9 @@ export function getDeploymentResult(commandOutput: string): DeploymentResult {
     };
 
     for (const key in parsed.properties.outputs) {
+      if (maskedOutputs && maskedOutputs.includes(key)) {
+        setSecret(parsed.properties.outputs[key].value.toString());
+      }
       outputs[key] = parsed.properties.outputs[key].value;
     }
   } catch (err) {

--- a/test/bicep/inputs-outputs.bicep
+++ b/test/bicep/inputs-outputs.bicep
@@ -5,4 +5,4 @@ param objectParam object
 output stringOutput string = stringParam
 output intOutput int = intParam
 output objectOutput object = objectParam
-output mySecret string = 'topsecret'
+output myServerIP string = '192.168.0.1'

--- a/test/bicep/inputs-outputs.bicep
+++ b/test/bicep/inputs-outputs.bicep
@@ -5,3 +5,4 @@ param objectParam object
 output stringOutput string = stringParam
 output intOutput int = intParam
 output objectOutput object = objectParam
+output mysecret string = 'mysecret'

--- a/test/bicep/inputs-outputs.bicep
+++ b/test/bicep/inputs-outputs.bicep
@@ -5,4 +5,4 @@ param objectParam object
 output stringOutput string = stringParam
 output intOutput int = intParam
 output objectOutput object = objectParam
-output mysecret string = 'mysecret'
+output mySecret string = 'topsecret'


### PR DESCRIPTION
# scenario
my bicep output a serverIP and I need reference that IP in later steps, with github syntax ${{ steps.deploy.outputs.myServerIP }}" I can use it as input, but github resolve that and print it in logs, which make myServerIP visible.

# github action secret feature
github does offer this [setSecret function](https://github.com/actions/toolkit/blob/main/packages/core/README.md#setting-a-secret), which will print *** for any string match any string marked as secret.

# solution
we take an extra option parameter in arm-deploy, maskedOutputs (multiline input with some limit, https://github.com/actions/toolkit/issues/184#issuecomment-1198653452), for any output key matched, we register the value as secret.

![Screenshot from 2024-09-18 12-53-18](https://github.com/user-attachments/assets/695ce87c-4b5b-4123-be99-c333944b68e9)


fix #197 #47 